### PR TITLE
Dev m2m knock fix

### DIFF
--- a/plugins/romloader/uart/romloader_uart_main.cpp
+++ b/plugins/romloader/uart/romloader_uart_main.cpp
@@ -220,7 +220,7 @@ bool romloader_uart::fix_deadloop()
 	uint8_t ucRetries = 5;
 	uint32_t ulDataReceived;
 	
-	
+	#define UART_MAXIMUM_PACKET_SIZE 2048
 	do
 	{
 		
@@ -230,7 +230,7 @@ bool romloader_uart::fix_deadloop()
 		{
 			sizTransfered = m_ptUartDev->RecvRaw(aucData, 1, 200);
 			ulDataReceived += sizTransfered;
-		} while( sizTransfered==1 || ulDataReceived > 100);
+		} while( sizTransfered==1 || ulDataReceived > UART_MAXIMUM_PACKET_SIZE);
 
 		
 		// try to get first char with timeout of 1000ms
@@ -257,6 +257,8 @@ bool romloader_uart::fix_deadloop()
 					ptPacketHeader = (MIV3_PACKET_HEADER_T*)aucData;
 					
 					// only packets that are sent in an endless loop are the following three
+					// note: the loop for waiting for an ACK for a CallMessage packet can be canceled by a CancelOperation packet 
+					//       but this will not stop the execution of the binary that sends these print messages.
 					if ( ptPacketHeader->s.ucPacketType==MONITOR_PACKET_TYP_Status ||
 						ptPacketHeader->s.ucPacketType==MONITOR_PACKET_TYP_ReadData ||
 						ptPacketHeader->s.ucPacketType==MONITOR_PACKET_TYP_CallMessage )
@@ -289,9 +291,7 @@ bool romloader_uart::fix_deadloop()
 					}
 				}
 			}
-			else{
-				
-			}
+
 		}
 		ucRetries--;
 	}while ( ucRetries > 0 && fResult == false);

--- a/plugins/romloader/uart/romloader_uart_main.cpp
+++ b/plugins/romloader/uart/romloader_uart_main.cpp
@@ -230,8 +230,6 @@ bool romloader_uart::fix_deadloop()
 	{
 		if( aucData[0]==MONITOR_STREAM_PACKET_START )
 		{
-			// set a default max packet size to 32
-			m_sizMaxPacketSizeClient = 32;
 			
 			sizTransfered += m_ptUartDev->RecvRaw(aucData+1, 4, 500);
 			m_ptLog->debug("sizTransfered: %d",sizTransfered);

--- a/plugins/romloader/uart/romloader_uart_main.cpp
+++ b/plugins/romloader/uart/romloader_uart_main.cpp
@@ -522,6 +522,13 @@ void romloader_uart::Connect(lua_State *ptClientData)
 			fResult = identify_loader(&tCmdSet, &tFnMi2);
 			if( fResult!=true )
 			{
+				m_ptLog->debug("Try to sync with cancel_operation");
+				fResult = synchronize(&tChiptyp);
+				m_ptLog->debug("Retry to identify loader");
+				fResult = identify_loader(&tCmdSet, &tFnMi2);
+			}
+			if( fResult!=true )
+			{
 				MUHKUH_PLUGIN_PUSH_ERROR(ptClientData, "%s(%p): failed to identify loader!", m_pcName, this);
 			}
 			else

--- a/plugins/romloader/uart/romloader_uart_main.h
+++ b/plugins/romloader/uart/romloader_uart_main.h
@@ -72,6 +72,7 @@ private:
 	} ROMLOADER_COMMANDSET_T;
 
 	bool identify_loader(ROMLOADER_COMMANDSET_T *ptCmdSet, romloader_uart_read_functinoid_mi2 *ptFnMi2);
+	bool fix_deadloop();
 
 	romloader_uart_device_platform *m_ptUartDev;
 


### PR DESCRIPTION
These changes can fix the following problem:

- netX is inside an endless loop waiting for an ACK packet that got lost
- Host process will not re-send the packet since the process ended (e.g. crashed or got cancelled)
- netX does not answer knock knock packets since it still waits for an ACK