### PR TITLE
[code] Added code to execute CPSID instruction when resetting IRQs (NXTFLASHER-755)

### DIFF
--- a/plugins/romloader/jtag/openocd/tcl/chip_init.tcl
+++ b/plugins/romloader/jtag/openocd/tcl/chip_init.tcl
@@ -147,9 +147,10 @@ proc deinit_breakpoint {} {
 		puts "Unknown chip type $iChiptyp"
 	}
 	
+	set strBreakpoints [bp]
 	echo "Remaining Breakpoints: "
 	echo "------------------------"
-	bp
+	echo $strBreakpoints
 	echo "------------------------"
 	echo ""
 }

--- a/plugins/romloader/jtag/openocd/tcl/jtag_detect_init.tcl
+++ b/plugins/romloader/jtag/openocd/tcl/jtag_detect_init.tcl
@@ -559,7 +559,8 @@ proc netX90_COM_disable_irqs {} {
 	# "Change PE State changes one or more of the PSTATE.{A, I, F} interrupt mask bits and, #
 	#  optionally, the PSTATE.M mode field, without changing any other PSTATE bits"         #
 	# CPSID bits: 1011|0110|0111|0AIF = 0xB67X                                              #
-	# See ARM Architecture reference manual F5.1.38 CPS,CPSID,CPSIE                         #
+	# See ARM Architecture reference manual (ARM DDI 0487J.a (ID042523))                    #
+	# Chapter F5.1.38 "CPS,CPSID,CPSIE"                                                     #
 
 	# NOP
 	mwh 0x00060000 0xBF00

--- a/plugins/romloader/jtag/openocd/tcl/jtag_detect_init.tcl
+++ b/plugins/romloader/jtag/openocd/tcl/jtag_detect_init.tcl
@@ -592,7 +592,17 @@ proc netX90_COM_disable_irqs {} {
 	bp 0x0006000E 2 hw
 	resume
 	echo "CPSID executed"
-	
+	if {[catch {halt $HALT_TIMEOUT} err] == 0} {
+		rbp 0x0006000E	
+	}else {
+		# The COM CPU wasn't halted.
+		puts "===================================================================="
+        puts "Timed out while waiting for halt."
+        puts "ERROR: Failed deinitialize IRQs"
+        puts "===================================================================="
+        shutdown error
+    }
+		
 	# Interrupt Active Bit Registers (see documentation 4.2.6)							  						  
 	set ADR_cm4_scs_nvic_iabr0 0xe000e300
 	set ADR_cm4_scs_nvic_iabr1 0xe000e304


### PR DESCRIPTION
Code to load a small program in machine instructions into the RAM and execute it.
Used for disabling the interrupts in the Program State Register.