### PR TITLE
[code] Fixed regression caused by undefined variable and missing space

### DIFF
--- a/plugins/romloader/jtag/openocd/tcl/jtag_detect_init.tcl
+++ b/plugins/romloader/jtag/openocd/tcl/jtag_detect_init.tcl
@@ -592,9 +592,10 @@ proc netX90_COM_disable_irqs {} {
 	bp 0x0006000E 2 hw
 	resume
 	echo "CPSID executed"
+	set HALT_TIMEOUT 2000
 	if {[catch {halt $HALT_TIMEOUT} err] == 0} {
 		rbp 0x0006000E	
-	}else {
+	} else {
 		# The COM CPU wasn't halted.
 		puts "===================================================================="
         puts "Timed out while waiting for halt."


### PR DESCRIPTION
This fixes a regression leading to OpenOCD throwing an error.
- The HALT_TIMEOUT variable was not defined in the context
- The space after { is necessary to avoid "Error: extra characters after close-brace"