### PR TITLE
Change datatype for sizRead, because size_t could never return -1

### DIFF
--- a/plugins/romloader/uart/romloader_uart_device_linux.cpp
+++ b/plugins/romloader/uart/romloader_uart_device_linux.cpp
@@ -41,8 +41,8 @@ void *romloader_uart_rx_thread(void *pvParameter)
 	bool fDestroy;
 	fd_set tRead;
 	struct timeval tTimeout;
-	size_t sizRead;
-	size_t sizWrite;
+	ssize_t sizRead;
+	ssize_t sizWrite;
 	int iResult;
 	ptrdiff_t iExitCode;
 	const size_t sizBufSize = 1024;


### PR DESCRIPTION
Return value written to sizRead causes -1 and -1 is 12510 as unsigned integer. The returned value is higher than 1024 and causes a segmentation fault